### PR TITLE
Copy node_modules into Mac application package

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -60,6 +60,11 @@ module.exports = function (grunt) {
           dest: '<%%= config.dist %>/node-webkit.app/Contents/Resources/',
           filter: 'isFile',
           src: '*.icns'
+        },{
+          expand: true,
+          cwd: '<%= config.app %>/../node_modules/',
+          dest: '<%= config.dist %>/node-webkit.app/Contents/Resources/app.nw/node_modules/',
+          src: '**'
         }]
       },
       webkit: {


### PR DESCRIPTION
This pull request targets issue [#21](https://github.com/Dica-Developer/generator-node-webkit/issues/21) in your repository, "node_modules directory not being imported".
