### PR TITLE
Change default string for CFBundleIconFile key

### DIFF
--- a/app/templates/mac/_Info.plist
+++ b/app/templates/mac/_Info.plist
@@ -13,7 +13,7 @@
 	<string>© <%= realname %>, 2013</string>
 	<% } %>
 	<key>CFBundleIconFile</key>
-	<string>icon.icns</string>
+	<string>nw.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/app/templates/mac/_Info.plist.tmp
+++ b/app/templates/mac/_Info.plist.tmp
@@ -13,7 +13,7 @@
 	<string>© <%= realname %>, 2013</string>
 	<% } %>
 	<key>CFBundleIconFile</key>
-	<string>icon.icns</string>
+	<string>nw.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
When running a build using the `grunt dist-mac` task, the .icns file in the resulting `.app` file is named nw.icns. The problem is that the CFBundleIconFile property in the related plist file was marked as `icons.icns`. This results in the icons being missing when you view the package, or run it.
