### PR TITLE
Modified app/_Gruntfile to make the createLinuxApp step copy over the ic...

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -243,7 +243,7 @@ module.exports = function (grunt) {
     var childProcess = require('child_process');
     var exec = childProcess.exec;
     var path = './' + (version === 'Linux64' ? config.distLinux64 : config.distLinux32);
-    exec('mkdir -p ' + path + '; cp resources/node-webkit/' + version + '/nw.pak ' + path + ' && cp resources/node-webkit/' + version + '/nw ' + path + '/node-webkit', function (error, stdout, stderr) {
+    exec('mkdir -p ' + path + '; cp resources/node-webkit/' + version + '/nw.pak ' + path + ' && cp resources/node-webkit/' + version + '/nw ' + path + '/node-webkit && cp resources/node-webkit/' + version + '/icudtl.dat ' + path + '/icudtl.dat', function (error, stdout, stderr) {
       var result = true;
       if (stdout) {
         grunt.log.write(stdout);


### PR DESCRIPTION
This is a proposed fix for issue 57, 'issue when running dist application on ubuntu 64'

I receive a similar error after running 'grunt dist-linux' and trying to start the application:

$ ./node-webkit app.nw/
[7651:1228/204657:FATAL:content_main_runner.cc(751)] Check failed: base::i18n::InitializeICU(). 
fish: Job 1, “./node-webkit app.nw/” terminated by signal SIGABRT (Abort)

The error signature is a little different than what was reported in the issue, but the main problem is the same: the icudtl.dat file is not being copied over from resources/node-webkit/Linux64/ to the dist/Linux64 folder.  If the file is copied over, the application will launch as expected.

This pull request makes a simple change in the Gruntfile so that the icudtl.dat is copied over every time that 'grunt dist-linux' is run.