### PR TITLE
Fix issue #75, fixes grunt dmg task by changing dist folders for Mac.

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -11,8 +11,8 @@ module.exports = function (grunt) {
   var config = {
     app: 'app',
     dist: 'dist',
-    distMac32: 'dist/MacOS32',
-    distMac64: 'dist/MacOS64',
+    distMac32: 'dist/macOS',
+    distMac64: 'dist/macOS',
     distLinux32: 'dist/Linux32',
     distLinux64: 'dist/Linux64',
     distWin: 'dist/Win',


### PR DESCRIPTION
Changes the names of mac dist folders to match the name referenced in the grunt dmg shell script. As discussed, the 32 and 64 bit builds use the same output folder and grunt dmg will generate the image using whichever was built last.