### PR TITLE
Fixed bug with webkit version validation

### DIFF
--- a/download/index.js
+++ b/download/index.js
@@ -26,7 +26,7 @@ module.exports = yeoman.generators.Base.extend({
   },
   _getDownloadTmpUrl: function(version) {
     var namePart = '/nwjs-';
-    if (this.nodeWebkitVersion.indexOf('v0.9.') !== -1 || this.nodeWebkitVersion.indexOf('v0.8.') !== -1 || this.nodeWebkitVersion.indexOf('v0.10.') !== -1 || this.nodeWebkitVersion.indexOf('v0.11.') !== -1) {
+    if (version.indexOf('v0.9.') !== -1 || version.indexOf('v0.8.') !== -1 || version.indexOf('v0.10.') !== -1 || version.indexOf('v0.11.') !== -1) {
       namePart = '/node-webkit-';
     }
     return 'http://dl.nwjs.io/' + version + namePart + version + '-linux-x64.tar.gz';


### PR DESCRIPTION
Validation failed with older versions of node webkit (prior to the renaming from node-webkit to nwjs).
`_getDownloadTmpUrl` was checking the wrong string when determining the version selected by the user, causing validation to fail and the generator to disallow installing v0.11 and older versions of node webkit.