### PR TITLE
Make all prompts optional.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -3,8 +3,12 @@ var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
 var _ = require('lodash');
+var optionOrPrompt = require('yeoman-option-or-prompt');
 
 module.exports = yeoman.generators.Base.extend({
+
+  _optionOrPrompt: optionOrPrompt,
+
   prompting: function () {
     var done = this.async();
     if(!this.options['skip-welcome']){
@@ -41,7 +45,7 @@ module.exports = yeoman.generators.Base.extend({
       }
     ];
 
-    this.prompt(prompts, function (props) {
+    this._optionOrPrompt(prompts, function (props) {
       this.appname = props.appname;
       this.description = props.description;
       this.username = props.username;
@@ -51,9 +55,9 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   compose: function () {
-    this.composeWith('node-webkit:download');
+    this.composeWith('node-webkit:download', { options: this.options });
     if(this.examples){
-      this.composeWith('node-webkit:examples');
+      this.composeWith('node-webkit:examples', { options: this.options });
     }
   },
 

--- a/generators/download/index.js
+++ b/generators/download/index.js
@@ -29,7 +29,7 @@ module.exports = yeoman.generators.Base.extend({
     var prompts = [
       {
         type: 'input',
-        name: 'downloadversion',
+        name: 'versionToDownload',
         message: 'Please specify which version of node-webkit you want to download',
         default: NWJS_DEFAULT_VERSION,
         validate: function (answer) {
@@ -110,9 +110,9 @@ module.exports = yeoman.generators.Base.extend({
   writing: {
     app: function () {
       var platformName = this.nwjs.platform,
-        taskname = platformName + '_' + this.nwjs.downloadversion,
+        taskname = platformName + '_' + this.nwjs.versionToDownload,
         srcFolder = this._getNwjsFolderName(),
-        nwExecutable = semver.outside(this.nwjs.downloadversion, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
+        nwExecutable = semver.outside(this.nwjs.versionToDownload, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
         templateFile;
 
       if (this.nwjs.platform.indexOf('Linux') > -1) {
@@ -143,7 +143,7 @@ module.exports = yeoman.generators.Base.extend({
 
   end: function () {
     this.log.ok('New grunt task generated.')
-      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.downloadversion)
+      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.versionToDownload)
       .writeln('');
   },
 
@@ -155,7 +155,7 @@ module.exports = yeoman.generators.Base.extend({
    * @private
    */
   _getDownloadUrl: function (version, platform) {
-    version = version || this.nwjs.downloadversion;
+    version = version || this.nwjs.versionToDownload;
     platform = platform || this.nwjs.platform;
     var namePart = '/nwjs-';
     if (semver.outside(version, 'v0.12.0', '<')) {
@@ -165,7 +165,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   _getNwjsFolderName: function () {
-    var version = this.nwjs.downloadversion,
+    var version = this.nwjs.versionToDownload,
       platform = this.nwjs.platform,
       namePart = 'nwjs-',
       platformFileName = PLATFORMS_MAP[platform],

--- a/generators/download/index.js
+++ b/generators/download/index.js
@@ -29,7 +29,7 @@ module.exports = yeoman.generators.Base.extend({
     var prompts = [
       {
         type: 'input',
-        name: 'versionToDownload',
+        name: 'nwjsVersion',
         message: 'Please specify which version of node-webkit you want to download',
         default: NWJS_DEFAULT_VERSION,
         validate: function (answer) {
@@ -110,9 +110,9 @@ module.exports = yeoman.generators.Base.extend({
   writing: {
     app: function () {
       var platformName = this.nwjs.platform,
-        taskname = platformName + '_' + this.nwjs.versionToDownload,
+        taskname = platformName + '_' + this.nwjs.nwjsVersion,
         srcFolder = this._getNwjsFolderName(),
-        nwExecutable = semver.outside(this.nwjs.versionToDownload, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
+        nwExecutable = semver.outside(this.nwjs.nwjsVersion, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
         templateFile;
 
       if (this.nwjs.platform.indexOf('Linux') > -1) {
@@ -143,7 +143,7 @@ module.exports = yeoman.generators.Base.extend({
 
   end: function () {
     this.log.ok('New grunt task generated.')
-      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.versionToDownload)
+      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.nwjsVersion)
       .writeln('');
   },
 
@@ -155,7 +155,7 @@ module.exports = yeoman.generators.Base.extend({
    * @private
    */
   _getDownloadUrl: function (version, platform) {
-    version = version || this.nwjs.versionToDownload;
+    version = version || this.nwjs.nwjsVersion;
     platform = platform || this.nwjs.platform;
     var namePart = '/nwjs-';
     if (semver.outside(version, 'v0.12.0', '<')) {
@@ -165,7 +165,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   _getNwjsFolderName: function () {
-    var version = this.nwjs.versionToDownload,
+    var version = this.nwjs.nwjsVersion,
       platform = this.nwjs.platform,
       namePart = 'nwjs-',
       platformFileName = PLATFORMS_MAP[platform],

--- a/generators/download/index.js
+++ b/generators/download/index.js
@@ -4,7 +4,8 @@
 var yeoman = require('yeoman-generator'),
   semver = require('semver'),
   request = require('request'),
-  fs = require('fs');
+  fs = require('fs'),
+  optionOrPrompt = require('yeoman-option-or-prompt');
 
 // Local
 var NWJS_DEFAULT_VERSION = 'v0.12.0',
@@ -19,6 +20,8 @@ var NWJS_DEFAULT_VERSION = 'v0.12.0',
 module.exports = yeoman.generators.Base.extend({
   nwjs: {},
 
+  _optionOrPrompt: optionOrPrompt,
+
   prompting: function () {
     var self = this,
       done = this.async();
@@ -26,7 +29,7 @@ module.exports = yeoman.generators.Base.extend({
     var prompts = [
       {
         type: 'input',
-        name: 'version',
+        name: 'downloadversion',
         message: 'Please specify which version of node-webkit you want to download',
         default: NWJS_DEFAULT_VERSION,
         validate: function (answer) {
@@ -82,7 +85,7 @@ module.exports = yeoman.generators.Base.extend({
         }
       }];
 
-    this.prompt(prompts, function (props) {
+    this._optionOrPrompt(prompts, function (props) {
       this.nwjs = props;
       done();
     }.bind(this));
@@ -107,9 +110,9 @@ module.exports = yeoman.generators.Base.extend({
   writing: {
     app: function () {
       var platformName = this.nwjs.platform,
-        taskname = platformName + '_' + this.nwjs.version,
+        taskname = platformName + '_' + this.nwjs.downloadversion,
         srcFolder = this._getNwjsFolderName(),
-        nwExecutable = semver.outside(this.nwjs.version, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
+        nwExecutable = semver.outside(this.nwjs.downloadversion, 'v0.12.0', '<') ? 'node-webkit' : 'nwjs',
         templateFile;
 
       if (this.nwjs.platform.indexOf('Linux') > -1) {
@@ -140,7 +143,7 @@ module.exports = yeoman.generators.Base.extend({
 
   end: function () {
     this.log.ok('New grunt task generated.')
-      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.version)
+      .info('grunt ' + this.nwjs.platform + '_' + this.nwjs.downloadversion)
       .writeln('');
   },
 
@@ -152,7 +155,7 @@ module.exports = yeoman.generators.Base.extend({
    * @private
    */
   _getDownloadUrl: function (version, platform) {
-    version = version || this.nwjs.version;
+    version = version || this.nwjs.downloadversion;
     platform = platform || this.nwjs.platform;
     var namePart = '/nwjs-';
     if (semver.outside(version, 'v0.12.0', '<')) {
@@ -162,7 +165,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   _getNwjsFolderName: function () {
-    var version = this.nwjs.version,
+    var version = this.nwjs.downloadversion,
       platform = this.nwjs.platform,
       namePart = 'nwjs-',
       platformFileName = PLATFORMS_MAP[platform],

--- a/generators/examples/index.js
+++ b/generators/examples/index.js
@@ -8,7 +8,8 @@ var yeoman = require('yeoman-generator'),
   fs = require('fs'),
   fsExtra = require('fs-extra'),
   url = require('url'),
-  inquirer = require('inquirer');
+  inquirer = require('inquirer'),
+  optionOrPrompt = require('yeoman-option-or-prompt');
 
 require('chalk');
 
@@ -51,6 +52,9 @@ module.exports = yeoman.generators.Base.extend({
   exampleList: [],
   EXAMPLES_ZIP_DESTINATION_PATH: '',
   EXAMPLES_EXTRACT_DESTINATION_PATH: '',
+
+  _optionOrPrompt: optionOrPrompt,
+
   initializing: {
     setup: function () {
       this.EXAMPLES_ZIP_DESTINATION_PATH = this.destinationPath('tmp/node-webkit-examples.zip');
@@ -88,7 +92,7 @@ module.exports = yeoman.generators.Base.extend({
         save: true
       }];
 
-    this.prompt(prompts, function (props) {
+    this._optionOrPrompt(prompts, function (props) {
       this.exampleName = props.exampleName;
       done();
     }.bind(this));

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "request": "^2.55.0",
     "semver": "^4.3.4",
     "yeoman-generator": "^0.19.0",
+    "yeoman-option-or-prompt": "^1.0.0",
     "yosay": "^1.0.2"
   },
   "devDependencies": {

--- a/test/download.js
+++ b/test/download.js
@@ -86,7 +86,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'versionToDownload': version,
+            'nwjsVersion': version,
             'platform': platform
           });
 
@@ -118,7 +118,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'versionToDownload': version,
+            'nwjsVersion': version,
             'platform': platform
           });
 
@@ -161,7 +161,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'versionToDownload': 'v0.12.0',
+          'nwjsVersion': 'v0.12.0',
           'platform': 'Linux64'
         });
 
@@ -227,7 +227,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'versionToDownload': 'v0.12.0',
+          'nwjsVersion': 'v0.12.0',
           'platform': 'MacOS64'
         });
 
@@ -306,7 +306,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'versionToDownload': 'v0.12.0',
+          'nwjsVersion': 'v0.12.0',
           'platform': 'Windows32'
         });
 
@@ -345,7 +345,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': 'v0.10.0',
+        'nwjsVersion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -361,7 +361,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': 'v0.10.0',
+        'nwjsVersion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -377,7 +377,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': 'v0.10.0',
+        'nwjsVersion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -400,7 +400,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': 'v0.10.0',
+        'nwjsVersion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -417,7 +417,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': 'v0.10.0',
+        'nwjsVersion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -445,7 +445,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': version,
+        'nwjsVersion': version,
         'platform': 'Linux64'
       });
 
@@ -461,7 +461,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': version,
+        'nwjsVersion': version,
         'platform': 'Linux64'
       });
 
@@ -477,7 +477,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': version,
+        'nwjsVersion': version,
         'platform': 'Linux64'
       });
 
@@ -500,7 +500,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': version,
+        'nwjsVersion': version,
         'platform': 'Linux64'
       });
 
@@ -517,7 +517,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'versionToDownload': version,
+        'nwjsVersion': version,
         'platform': 'Linux64'
       });
 

--- a/test/download.js
+++ b/test/download.js
@@ -86,7 +86,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'version': version,
+            'downloadversion': version,
             'platform': platform
           });
 
@@ -118,7 +118,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'version': version,
+            'downloadversion': version,
             'platform': platform
           });
 
@@ -161,7 +161,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'version': 'v0.12.0',
+          'downloadversion': 'v0.12.0',
           'platform': 'Linux64'
         });
 
@@ -227,7 +227,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'version': 'v0.12.0',
+          'downloadversion': 'v0.12.0',
           'platform': 'MacOS64'
         });
 
@@ -306,7 +306,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'version': 'v0.12.0',
+          'downloadversion': 'v0.12.0',
           'platform': 'Windows32'
         });
 
@@ -345,7 +345,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': 'v0.10.0',
+        'downloadversion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -361,7 +361,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': 'v0.10.0',
+        'downloadversion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -377,7 +377,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'version': 'v0.10.0',
+        'downloadversion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -400,7 +400,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'version': 'v0.10.0',
+        'downloadversion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -417,7 +417,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': 'v0.10.0',
+        'downloadversion': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -445,7 +445,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': version,
+        'downloadversion': version,
         'platform': 'Linux64'
       });
 
@@ -461,7 +461,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': version,
+        'downloadversion': version,
         'platform': 'Linux64'
       });
 
@@ -477,7 +477,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'version': version,
+        'downloadversion': version,
         'platform': 'Linux64'
       });
 
@@ -500,7 +500,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'version': version,
+        'downloadversion': version,
         'platform': 'Linux64'
       });
 
@@ -517,7 +517,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'version': version,
+        'downloadversion': version,
         'platform': 'Linux64'
       });
 

--- a/test/download.js
+++ b/test/download.js
@@ -86,7 +86,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'downloadversion': version,
+            'versionToDownload': version,
             'platform': platform
           });
 
@@ -118,7 +118,7 @@ describe('node-webkit:download', function () {
             .reply(200, {});
 
           helpers.mockPrompt(gen, {
-            'downloadversion': version,
+            'versionToDownload': version,
             'platform': platform
           });
 
@@ -161,7 +161,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'downloadversion': 'v0.12.0',
+          'versionToDownload': 'v0.12.0',
           'platform': 'Linux64'
         });
 
@@ -227,7 +227,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'downloadversion': 'v0.12.0',
+          'versionToDownload': 'v0.12.0',
           'platform': 'MacOS64'
         });
 
@@ -306,7 +306,7 @@ describe('node-webkit:download', function () {
 
         helpers.mockPrompt(appGenerator, defaultOptions);
         helpers.mockPrompt(gen, {
-          'downloadversion': 'v0.12.0',
+          'versionToDownload': 'v0.12.0',
           'platform': 'Windows32'
         });
 
@@ -345,7 +345,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': 'v0.10.0',
+        'versionToDownload': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -361,7 +361,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': 'v0.10.0',
+        'versionToDownload': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -377,7 +377,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'downloadversion': 'v0.10.0',
+        'versionToDownload': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -400,7 +400,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/node-webkit-v0.10.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'downloadversion': 'v0.10.0',
+        'versionToDownload': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -417,7 +417,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': 'v0.10.0',
+        'versionToDownload': 'v0.10.0',
         'platform': 'Linux64'
       });
 
@@ -445,7 +445,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': version,
+        'versionToDownload': version,
         'platform': 'Linux64'
       });
 
@@ -461,7 +461,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': version,
+        'versionToDownload': version,
         'platform': 'Linux64'
       });
 
@@ -477,7 +477,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'downloadversion': version,
+        'versionToDownload': version,
         'platform': 'Linux64'
       });
 
@@ -500,7 +500,7 @@ describe('node-webkit:download', function () {
         .replyWithFile(200, __dirname + '/package_fixtures/nwjs-v0.12.0-linux-x64.tar.gz');
 
       helpers.mockPrompt(gen, {
-        'downloadversion': version,
+        'versionToDownload': version,
         'platform': 'Linux64'
       });
 
@@ -517,7 +517,7 @@ describe('node-webkit:download', function () {
         .reply(200, {});
 
       helpers.mockPrompt(gen, {
-        'downloadversion': version,
+        'versionToDownload': version,
         'platform': 'Linux64'
       });
 


### PR DESCRIPTION
If options are passed in via command-line args or a composeWith parameter, then those options will be used and the corresponding prompts will be skipped.